### PR TITLE
Fixed non consistent check of payload encoding.

### DIFF
--- a/src/ios/Dgram.m
+++ b/src/ios/Dgram.m
@@ -148,7 +148,7 @@
     CDVPluginResult *result = nil;
 
     NSData *data = nil;
-    if ([encoding isEqualToString:@"utf8"])
+    if ([encoding isEqualToString:@"utf-8"])
         data = [buffer dataUsingEncoding:NSUTF8StringEncoding];
     else if ([encoding isEqualToString:@"base64"])
         data = [[NSData alloc] initWithBase64EncodedString:buffer options:0];


### PR DESCRIPTION
The default encoding is set to "utf-8" on JS.
This encoding is checked in the native code for each plaform. 
There was an inconsistency between Android and iOS in this check.
